### PR TITLE
Fix compile error and gitignore automatically generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,10 @@ bin
 mapleseed.rc
 /resources/binaries
 /bin-32
+
+# Leftovers
+*.stash
+*.json
+*.log
+ui_mainwindow.h
+MapleSeed

--- a/mapleseed.pro
+++ b/mapleseed.pro
@@ -67,11 +67,13 @@ else: unix:!android: target.path = /opt/$${TARGET}/bin
 !isEmpty(target.path): INSTALLS += target
 
 contains(QT_ARCH, x86_64) {
-unix|win32: LIBS += -LC:/Qt/Tools/OpenSSL/Win_x64/lib/ -llibcrypto
-INCLUDEPATH += C:/Qt/Tools/OpenSSL/Win_x64/include
-DEPENDPATH += C:/Qt/Tools/OpenSSL/Win_x64/include
+win32: LIBS += -LC:/Qt/Tools/OpenSSL/Win_x64/lib/ -llibcrypto
+win32: INCLUDEPATH += C:/Qt/Tools/OpenSSL/Win_x64/include
+win32: DEPENDPATH += C:/Qt/Tools/OpenSSL/Win_x64/include
 } else {
-unix|win32: LIBS += -LC:/Qt/Tools/OpenSSL/Win_x86/lib/ -llibcrypto
-INCLUDEPATH += C:/Qt/Tools/OpenSSL/Win_x86/include
-DEPENDPATH += C:/Qt/Tools/OpenSSL/Win_x86/include
+win32: LIBS += -LC:/Qt/Tools/OpenSSL/Win_x86/lib/ -llibcrypto
+win32: INCLUDEPATH += C:/Qt/Tools/OpenSSL/Win_x86/include
+win32: DEPENDPATH += C:/Qt/Tools/OpenSSL/Win_x86/include
 }
+
+unix: LIBS += -lcrypto

--- a/src/cemu/crypto.h
+++ b/src/cemu/crypto.h
@@ -9,8 +9,8 @@
 #include <QFile>
 #include <QDataStream>
 
-#include <openssl\aes.h>
-#include <openssl\sha.h>
+#include <openssl/aes.h>
+#include <openssl/sha.h>
 
 class CemuCrypto : public QObject
 {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -99,14 +99,15 @@ void MainWindow::executeCemu(QString rpxPath)
     QFileInfo rpx(rpxPath);
     if (rpx.exists())
     {
-        QString args("-g \"" + rpx.filePath() + "\"");
+        QStringList args;
+        args << "-g \"" + rpx.filePath() + "\"";
         if (Settings::value("cemu/fullscreen").toBool())
         {
-            args.append(" -f");
+            args << " -f";
         }
         QString file(Settings::value("cemu/path").toString());
         process->setWorkingDirectory(QFileInfo(file).dir().path());
-        process->setNativeArguments(args);
+        process->setArguments(args);
         process->setProgram(file);
         process->start();
     }


### PR DESCRIPTION
Fixes some errors and adds Linux compiling ability.

To compile for Linux:
```
apt-get install libqt5gamepad5-dev libssl-dev build-essential qt5-qmake gcc
qmake
make
```
I may have left some out, because I am not really sure what all that requires. Let me know if you run into issues.

Link to a precompiled release for both **Windows** and **Linux** https://github.com/stevenlafl/Mapleseed/releases/tag/1.1.1

Addresses Linux: 
```
In file included from src/cemu/crypto.cpp:2:
src/cemu/crypto.h:12:10: fatal error: openssl\aes.h: No such file or directory
 #include <openssl\aes.h>
          ^~~~~~~~~~~~~~~
```

Addresses QT:
```
src/mainwindow.cpp: In member function ‘void MainWindow::executeCemu(QString)’:
src/mainwindow.cpp:109:18: error: ‘class QProcess’ has no member named ‘setNativeArguments’; did you mean ‘setArguments’?
         process->setNativeArguments(args);
                  ^~~~~~~~~~~~~~~~~~
```